### PR TITLE
Include LICENSE file in wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ long_description = file: README.md
 url = https://github.com/Who8MyLunch/Jupyter_Video_Widget
 keywords = ipython, jupyter, widgets, video, html5, player
 license = MIT
+license_file = LICENSE
 platform = Jupyter
 
 


### PR DESCRIPTION
The license requires that all copies of the software include the license.  This makes sure the license is included in the wheels.  See the wheel documentation [here](https://wheel.readthedocs.io/en/stable/#including-the-license-in-the-generated-wheel-file) for more information.